### PR TITLE
Add missing wheel dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ requires=[
     'docutils',
     'quantiphy>=2.1.0',
     'inform>=1.9',
+    'wheel',
 ]
 
 setup(


### PR DESCRIPTION
Add missing wheel dependency. Without this dependency line, running setup.py fails on:

error: invalid command 'bdist_wheel'