### PR TITLE
Add readline functions to ec

### DIFF
--- a/engineering_calculator/main.py
+++ b/engineering_calculator/main.py
@@ -64,6 +64,7 @@ from docopt import docopt
 from inform import Color, display, error, fatal, Inform, os_error, warn, terminate
 from os.path import expanduser
 import sys, os
+import readline
 
 # Read command line {{{1
 def main():


### PR DESCRIPTION
With importing readline module to ec, the interactive prompt supports readline functions, which makes ec more usable.

1. Support shortcuts, such as, Ctrl+h, Ctrl+w, Ctrl+b, Ctrl+f and more.
2. Support history (current prompt).